### PR TITLE
feat-custom-node: Add custom node class to replace pydot nodes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-test*
 .idea
 .idea
 img

--- a/tests/test_node.py
+++ b/tests/test_node.py
@@ -1,0 +1,40 @@
+from visualiser import *
+
+"""
+    Test case class for nodes 
+"""
+class TestNode:
+    def test_create_new_node(self):
+        node = Node('bishal', 'Bishal label', color='red', style='filled')
+
+        assert node.label == 'Bishal label'
+        assert node.name == 'bishal'
+        assert node.get_attribute('color') == 'red'
+        assert node.get_attribute('style') == 'filled'
+        assert node.to_string() == 'bishal [label="Bishal label", color="red", style="filled"];'
+
+    def test_set_attributes(self):
+        node = Node('bishal', 'Bishal label', color='red', style='filled')
+        assert node.get_attribute('color') == 'red'
+        node.set_attribute('color', 'green')
+        assert node.get_attribute('color') == 'green'
+        node.set_attribute('background', 'grey')
+        assert node.get_attribute('background') == 'grey'
+        assert node.to_string() == 'bishal [label="Bishal label", color="green", style="filled", background="grey"];'
+
+    def test_rename_name_label(self):
+        node = Node('bishal', 'Bishal label', color='red', style='filled')
+
+        node.set_attribute('color', 'green')
+
+        assert node.label == 'Bishal label'
+        node.label = 'Bishal renamed label'
+        assert node.label == 'Bishal renamed label'
+
+        assert node.name == 'bishal'
+        node.name = 'Bishal renamed'
+        assert node.name == 'Bishal renamed'
+
+        assert node.to_string() == 'Bishal renamed [label="Bishal renamed label", color="green", style="filled"];'
+
+

--- a/visualiser/__init__.py
+++ b/visualiser/__init__.py
@@ -1,3 +1,5 @@
-
 # Version of the recursion-visualiser
 __version__ = "1.0.1"
+
+from  .node import Node
+from visualiser import *

--- a/visualiser/node.py
+++ b/visualiser/node.py
@@ -1,0 +1,45 @@
+class Node:
+    def __init__(self, name, label='', **attrs):
+        # TODO: Add support for initialization of attributes from attribute dict
+        self._name = name
+        self._attrs = attrs
+
+        if len(label) == 0:
+            self._label = name
+        else:
+            self._label = label
+
+    def __repr__(self):
+        return f"Node('{self.name}')"
+
+    @property
+    def name(self):
+        return self._name
+
+    @name.setter
+    def name(self, _name):
+        self._name = _name
+
+    @property
+    def label(self):
+        return self._label
+
+    @label.setter
+    def label(self, _label):
+        self._label = _label
+
+    def get_attribute(self, key):
+        return self._attrs[key]
+
+    def set_attribute(self, key, value):
+        self._attrs[key] = value
+
+    def remove_attribute(self, key):
+        del self._attrs[key]
+
+    def get_attributes_string(self):
+        return '[' + f'label="{self._label}", ' + ', '.join(
+            [f'{key}="{value}"' for key, value in self._attrs.items()]) + '];'
+
+    def to_string(self):
+        return f'{self.name} {self.get_attributes_string()}'


### PR DESCRIPTION
## Description
This PR adds a custom node class to replace pydot Node and have more granular control creating node, adding/removing attributes, getting dot string etc