### PR TITLE
fix minsave duration parameter

### DIFF
--- a/visualiser/visualiser.py
+++ b/visualiser/visualiser.py
@@ -82,7 +82,7 @@ class Visualiser(object):
         for filename in sorted_images:
             images.append(imageio.imread(filename))
         print("Writing gif...")
-        imageio.mimsave(name, images, duration=delay)
+        imageio.mimsave(name, images, fps=delay)
         print(f"Saved gif {name} successfully")
         # Delete temporary directory
         shutil.rmtree("frames")


### PR DESCRIPTION
The PR is to fix the animation frequency while generating the gif using `recursion-tree-visualizer` package.
While using the code below 

```
@classmethod
    def write_gif(cls, name="out.gif", delay=3):
        images = []

        # sort frames images in ascending order to number in image filename
        # image filename: frames/temp_1.png
        sorted_images = sorted(
            glob.glob("frames/*.png"),
            key=lambda fn: int(fn.split("_")[1].split(".")[0])
        )

        for filename in sorted_images:
            images.append(imageio.imread(filename))
        print("Writing gif...")
        imageio.mimsave(name, images, duration=delay)
        print(f"Saved gif {name} successfully")
        # Delete temporary directory
        shutil.rmtree("frames")
```

It does generate the gifs properly, however. changing the `delay` parameter in `vs.make_animation("fibonacci.gif", delay=0.5) ` from `10` --> `1` , or any other value does not make any difference.

```
def main():
    # Call function
    print(fib(n=6))
    # Save recursion tree to a file
    vs.make_animation("fibonacci.gif", delay=0.5)
```
     
The gif is still generated, and each node are displayed in a constant speed which is very fast.

Apparently changing the `duration` parameter to `fps` changes the speed in which each node is generated in the gif.