### PR TITLE
Escape { to support dictionary in params

### DIFF
--- a/visualiser/visualiser.py
+++ b/visualiser/visualiser.py
@@ -175,6 +175,7 @@ class Visualiser(object):
             # Current function signature looks as follows:
             # foo(1, 31, 0) or foo(a=1, b=31, c=0)
             function_signature = f"{function_name}({signature_args_string})"
+            # Pydot needs us to escape certain special chars, namely { } and < > 
             function_label = re.escape(function_label)
             function_label = function_label.replace("<","\<").replace(">","\>")
             """"""

--- a/visualiser/visualiser.py
+++ b/visualiser/visualiser.py
@@ -249,11 +249,12 @@ class Visualiser(object):
             if self.show_return_value:
                 # If shape is set to record
                 # Then separate function label and return value by a row
+                escaped_return_value = re.escape(str(result)).replace("<", "\<").replace(">", "\>")
                 if "record" in self.node_properties_kwargs.values():
                     function_label = "{" + \
-                        function_label + f"|{result} }}"
+                        function_label + f"|{escaped_return_value} }}"
                 else:
-                    function_label += f"\n => {result}"
+                    function_label += f"\n => {escaped_return_value}"
 
             child_node = pydot.Node(name=function_signature,
                                     label=function_label,

--- a/visualiser/visualiser.py
+++ b/visualiser/visualiser.py
@@ -175,7 +175,7 @@ class Visualiser(object):
             # Current function signature looks as follows:
             # foo(1, 31, 0) or foo(a=1, b=31, c=0)
             function_signature = f"{function_name}({signature_args_string})"
-            function_label = f"{function_name}({label_args_string})"
+            function_label = f"{function_name}({label_args_string})".replace("{","\{").replace("}","\}")
             """"""
 
             """Details about caller function"""

--- a/visualiser/visualiser.py
+++ b/visualiser/visualiser.py
@@ -175,7 +175,8 @@ class Visualiser(object):
             # Current function signature looks as follows:
             # foo(1, 31, 0) or foo(a=1, b=31, c=0)
             function_signature = f"{function_name}({signature_args_string})"
-            function_label = f"{function_name}({label_args_string})".replace("{","\{").replace("}","\}")
+            function_label = re.escape(function_label)
+            function_label = function_label.replace("<","\<").replace(">","\>")
             """"""
 
             """Details about caller function"""


### PR DESCRIPTION
## Problem 
Right now, if the function which we are visualizing the recursion for has a dictionary or defaultdict in it's param list, I get this error on my mac:

Error: bad label format fib(d={}, n=1)
## How to repro:

With the default example provided in the readme, pass in a dictionary to fibonnaci:

```
# Add decorator
# Decorator accepts optional arguments: ignore_args , show_argument_name, show_return_value and node_properties_kwargs
@vs(node_properties_kwargs={"shape":"record", "color":"#f57542", "style":"filled", "fillcolor":"grey"})
def fib(n,d={}):
    if n <= 1:
        return n
    return fib(n=n - 1, d={}) + fib(n=n - 2, d={'1':'2'})
```

## Solution

If I escape { and }, the error goes away for dictionary and set. For default dict, I also need to escape < and > Not sure if there are any other special chars that need to be escaped because the pydot spec isn't particularly clear, but since dictionary and set both use { and } and those are both used often I figured I'd push this for now. Fix tested locally with the fibonacci example by adding a dictionary filled with arbitrary values to the param list of the fibonacci function. 


